### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   aptabase_db:
     container_name: aptabase_db


### PR DESCRIPTION
Without specifying the version, I get errors:
```
$ docker-compose up -d
>>> ERROR: The Compose file './docker-compose.yml' is invalid because:
>>> Unsupported config option for services: 'aptabase_events_db'
>>> Unsupported config option for volumes: 'events-db-data'
```